### PR TITLE
Instaparse/toml abnf

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
   :author "Luca Antiga"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [instaparse "1.3.5"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [instaparse "1.4.8"]
+                 [clojure.java-time "0.3.1"]])

--- a/src/clj_toml/core.clj
+++ b/src/clj_toml/core.clj
@@ -2,136 +2,535 @@
   ^{:doc "TOML for Clojure"
     :author "Luca Antiga"}
   (:use [instaparse.core :as insta]
-        [clojure.instant :only [read-instant-timestamp]])
-  (:require [clojure.string :as s]))
-
+        [clojure.instant :only [read-instant-timestamp]]
+        [clojure.string :only [replace-first]]
+        [java-time :only [local-time]])
+  (:require [clojure.string :as s]
+            [clojure.zip :as z]))
 
 (def toml-grammar
   "
-  <TOML> = <n*> root-table? <n*> tables* <n*>
+  ;; Overall Structure
 
-  root-table = root-table-content
-  <root-table-content> = <s*> pair <s*> | <s*> pair <s*> <n+> root-table-content
+  toml = expression *( <newline> expression )
 
-  <tables> = (table | table-array) | (table | table-array) <n+> tables
+  <expression> =  <ws> [ <comment> ]
+  <expression> =/ <ws> keyval <ws> [ <comment> ]
+  <expression> =/ <ws> table <ws> [ <comment> ]
 
-  table = table-name <n*> table-content
-  table-name = <s*> <'['> <s*> dotted-name <s*> <']'> <s*>
-  table-content = table-content-rec
-  <table-content-rec> = <s*> pair <s*> | <s*> pair <s*> <n+> table-content-rec
+  ;; Whitespace
 
-  table-array = table-array-name <n*> table-array-content
-  table-array-name = <s*> <'[['> <s*> dotted-name <s*> <']]'> <s*>
-  table-array-content = table-array-content-rec
-  <table-array-content-rec> = <s*> pair <s*> | <s*> pair <s*> <n+> table-array-content-rec
+  ws = *wschar
 
-  <dotted-name> = key | key <s*> <'.'> <s*> dotted-name
+  wschar =  %x20  ; Space
+  wschar =/ %x09  ; Horizontal tab
 
-  <pair> = key <s*> <'='> <s*> value
+  ;; Newline
 
-  <key> = identifier | string
+  newline =  %x0A     ; LF
+  newline =/ %x0D.0A  ; CRLF
 
-  <value> = inline-table | array | primitive
+  ;; Comment
 
-  inline-table = <'{'> <s*> inline-table-content <s*> <'}'>
-  <inline-table-content> = pair <s*> <','?> | pair <s*> <','> <s*> inline-table-content
- 
-  array = <'['> <s*> <n*> array-content <n*> <s*> <']'>
-  <array-content> = <s*> primitive <s*> <n*> <','?> <s*> <n*> | <s*> primitive <s*> <n*> <','> <s*> <n*> array-content
- 
-  <primitive> = timestamp | integer | float | boolean | string
+  comment-start-symbol = %x23 ; #
+  non-eol =  %x09
+  non-eol =/ %x20-10FFFF
 
-  timestamp = #'(\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:\\d{2}:\\d{2}(\\.\\d*)?)([zZ]|([+\\-])(\\d{2}):?(\\d{2}))'
+  comment = comment-start-symbol *non-eol
 
-  boolean = 'true' | 'false'
+  ;; Key-Value pairs
 
-  integer = int
-  float = (sign? frac) | (int frac) | (int exp) | (int frac exp) | (float 'M')
-  <int> = (sign? digit_) | (sign? #'[1-9]' digits_) | (int 'M')
-  <sign> = '+' | '-'
-  <frac> = '.' digits_
-  <exp> = ex digits_
-  <digits_> = digit_ | (digit_ digits_)
-  <digit_> = digit | <'_'>
-  <digits> = digit | (digit digits)
-  <digit> = #'[0-9]'
-  <ex> = 'e' | 'e+' | 'e-' | 'E' | 'E+' | 'E-'
+  keyval = key <keyval-sep> val
 
-  string = <'\"'> string-content <'\"'>
-  <string-content> = #'[^\"\n]*'
+  key = unquoted-key / quoted-key
+  <unquoted-key> = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
+  <quoted-key> = basic-string / literal-string
 
-  identifier = #'[a-zA-Z0-9_-]+' 
+  keyval-sep = ws %x3D ws ; =
 
-  <n> = <s*> <comment?> '\n'
-  <comment> = #'#[^\n]*'
-  <s> = ' '
+  <val> = string / boolean / array / inline-table / date-time / float / integer
+
+  ;; Table
+
+  <table> = table-name expression
+  <table-name> = std-table / array-table
+
+  ;; Standard Table
+
+  std-table = <std-table-open> key *( <table-key-sep> key ) <std-table-close>
+
+  <std-table-open>  = %x5B ws     ; [ Left square bracket
+  <std-table-close> = ws %x5D     ; ] Right square bracket
+  <table-key-sep>   = ws %x2E ws  ; . Period
+
+  ;; String
+
+  <string> = ml-basic-string / basic-string / ml-literal-string / literal-string
+
+  ;; Basic String
+
+  basic-string = <quotation-mark> *basic-char <quotation-mark>
+
+  quotation-mark = %x22            ; \"
+
+  <basic-char> = basic-unescaped / escaped
+  <basic-unescaped> = %x20-21 / %x23-5B / %x5D-7E / %x80-10FFFF
+  <escape> = %x5C                    ; \\
+
+  <escaped> = escape escape-seq-char
+
+  escape = %x5C                          ; \\
+  escape-seq-char =  escape %x22         ; \"    quotation mark  U+0022
+  escape-seq-char =/ escape %x5C         ; \\    reverse solidus U+005C
+  escape-seq-char =/ escape %x2F         ; /     solidus         U+002F
+  escape-seq-char =/ escape %x62         ; b     backspace       U+0008
+  escape-seq-char =/ escape %x66         ; f     form feed       U+000C
+  escape-seq-char =/ escape %x6E         ; n     line feed       U+000A
+  escape-seq-char =/ escape %x72         ; r     carriage return U+000D
+  escape-seq-char =/ escape %x74         ; t     tab             U+0009
+  escape-seq-char =/ escape %x75 4HEXDIG ; uXXXX                U+XXXX
+  escape-seq-char =/ escape %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
+
+  ;; Multiline literals
+
+  <ml-newline> = ( %x0A /              ; LF
+                   %x0D.0A )           ; CRLF
+
+  ;; Multiline Basic String
+
+  ml-basic-string = <ml-basic-string-delim> ml-basic-body <ml-basic-string-delim>
+
+  ml-basic-string-delim = 3quotation-mark
+
+  <ml-basic-body> = *( ml-basic-char / ml-newline / ( escape ws ml-newline ) )
+  <ml-basic-char> = ml-basic-unescaped / escaped
+  <ml-basic-unescaped> = %x20-5B / %x5D-10FFFF
+
+  ;; Literal String
+
+  literal-string = <apostrophe> *literal-char <apostrophe>
+
+  apostrophe = %x27 ; ' apostrophe
+
+  <literal-char> = %x09 / %x20-26 / %x28-10FFFF
+
+  ;; Multiline Literal String
+
+  ml-literal-string = <ml-literal-string-delim> ml-literal-body <ml-literal-string-delim>
+
+  ml-literal-string-delim = 3apostrophe
+
+  <ml-literal-body> = *( ml-literal-char / ml-newline )
+  <ml-literal-char> = %x09 / %x20-10FFFF
+
+  ;; Integer
+
+  integer = integer-core
+
+  <integer-core> = [ minus / plus ] int
+  <minus> = %x2D                       ; -
+  <plus> = %x2B                        ; +
+
+  <int> = DIGIT / digit1-9 1*( DIGIT / <underscore> DIGIT )
+  <digit1-9> = %x31-39               ; 1-9
+  underscore = %x5F                  ; _
+
+  ;; Float
+
+  float = integer-core ( exp / frac [ exp ] )
+  float =/ special-float
+
+  <frac> = decimal-point zero-prefixable-int
+  <decimal-point> = %x2E               ; .
+  <zero-prefixable-int> = DIGIT *( DIGIT / <underscore> DIGIT )
+
+  <exp> = \"e\" integer-core
+
+  <special-float> = [ minus / plus ] ( inf / nan )
+  <inf> = %x69.6e.66  ; inf
+  <nan> = %x6e.61.6e  ; nan
+
+  ;; Boolean
+
+  boolean = true / false
+
+  true    = <%x74.72.75.65>     ; true
+  false   = <%x66.61.6C.73.65>  ; false
+
+  ;; Date and Time (as defined in RFC 3339)
+
+  date-time      = offset-date-time / local-date-time / local-date / local-time
+
+  <date-fullyear>  = 4DIGIT
+  <date-month>     = 2DIGIT  ; 01-12
+  <date-mday>      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+  <time-delim>     = \"T\" / %x20 ; T, t or space
+  <time-hour>      = 2DIGIT  ; 00-23
+  <time-minute>    = 2DIGIT  ; 00-59
+  <time-second>    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+  <time-secfrac>   = \".\" 1*DIGIT
+  <time-numoffset> = ( \"+\" / \"-\" ) time-hour \":\" time-minute
+  <time-offset>    = \"Z\" / time-numoffset
+
+  <partial-time>   = time-hour \":\" time-minute \":\" time-second [ time-secfrac ]
+  <full-date>      = date-fullyear \"-\" date-month \"-\" date-mday
+  <full-time>      = partial-time time-offset
+
+  ;; Offset Date-Time
+
+  offset-date-time = full-date time-delim full-time
+
+  ;; Local Date-Time
+
+  local-date-time = full-date time-delim partial-time
+
+  ;; Local Date
+
+  local-date = full-date
+
+  ;; Local Time
+
+  local-time = partial-time
+
+  ;; Array
+
+  array = <array-open> [ array-values ] <ws-comment-newline> <array-close>
+
+  array-open  = %x5B ; [
+  array-close = %x5D ; ]
+
+  <array-values> = <ws-comment-newline> val <ws> <array-sep> array-values
+  <array-values> =/ <ws-comment-newline> val <ws> [ <array-sep> ]
+
+  array-sep = %x2C  ; , Comma
+
+  ws-comment-newline = *( wschar / [ comment ] newline )
+
+  ;; Inline Table
+
+  inline-table = <inline-table-open> inline-table-keyvals <inline-table-close>
+
+  inline-table-open  = %x7B ws     ; {
+  inline-table-close = ws %x7D     ; }
+  inline-table-sep   = ws %x2C ws  ; , Comma
+
+  <inline-table-keyvals> = [ inline-table-keyvals-non-empty ]
+  <inline-table-keyvals-non-empty> = key <keyval-sep> val [ <inline-table-sep> inline-table-keyvals-non-empty ]
+
+  ;; Array Table
+
+  array-table = <array-table-open> key *( <table-key-sep> key ) <array-table-close>
+
+  array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
+  array-table-close = ws %x5D.5D  ; ]] Double right square bracket
+
+  ;; Built-in ABNF terms, reproduced here for clarity
+
+  <ALPHA> = %x41-5A / %x61-7A ; A-Z / a-z
+  <DIGIT> = %x30-39 ; 0-9
+  <HEXDIG> = DIGIT / \"A\" / \"B\" / \"C\" / \"D\" / \"E\" / \"F\"
   ")
 
 ;; TODO:
-;; multiline strings
-;; force arrays to be homogenous
 ;; repeating table names is invalid
+;; non-homogenous array types
 
-(defn- to-map [xs]
-  (->> xs (partition 2) (map vec) (into {})))
-
-(defn- to-entry [entry-type ks xs]
-  {:entry-type entry-type
-   :keys (vec ks)
-   :value (to-map xs)})
-
-(defn- merge-entries [res {entry-type :entry-type ks :keys entry-value :value}]
-  (if (= entry-type :root-table) 
-    (merge res entry-value)
-    (let [ks (reduce 
-               (fn [out k]
-                 (let [v (get-in res out)]
-                   (if (vector? v) 
-                     (concat out [(dec (count v)) k])
-                     (conj out k)))) 
-               [] ks)]
-      (if (get-in res ks) 
-        (condp = entry-type
-          :table (update-in res ks merge entry-value)
-          :table-array (update-in res ks conj entry-value))
-        (condp = entry-type
-          :table (assoc-in res ks entry-value)
-          :table-array (assoc-in res ks [entry-value]))))))
- 
 (def toml-parser
-  (insta/parser toml-grammar))
+  (insta/parser toml-grammar :input-format :abnf))
+
+(defn- convert-boolean
+  "Converts value in form [keyword] into Clojure boolean type."
+  [x]
+  (let [value (first x)]
+    (= value :true)))
+
+(defn- convert-array
+  "Converts value from sequence to array."
+  [& xs]
+  (vec xs))
+
+(defn- convert-float
+  "Converts value in form [keyword] into Clojure float type."
+  [x]
+  (condp = x
+    "-inf" Double/NEGATIVE_INFINITY
+    "+inf" Double/POSITIVE_INFINITY
+    "inf" Double/POSITIVE_INFINITY
+    "-nan" Double/NaN
+    "+nan" Double/NaN
+    "nan" Double/NaN
+    (read-string x)))
 
 (def toml-transform
   (partial insta/transform
-           {:float (comp read-string str) 
-            :integer (comp read-string str)
-            :boolean read-string
-            :timestamp read-instant-timestamp
-            :string str
-            :identifier str
-            :array (fn [& xs] (into [] xs))
-            :inline-table (fn [& xs] (to-map xs))
-            :root-table (fn [& xs] (to-entry :root-table nil xs))
-            :table (fn 
-                     ([[_ & ks]] (to-entry :table ks []))
-                     ([[_ & ks] [_ & xs]] (to-entry :table ks xs)))
-            :table-array (fn 
-                           ([[_ & ks]] (to-entry :table-array ks []))
-                           ([[_ & ks] [_ & xs]] (to-entry :table-array ks xs)))}))
+           {:keyval            (fn [k v]
+                                 (if (and (sequential? v) (= :inline-table (first v)))
+                                   [:inline-table k v]
+                                   [:keyval k v]))
+            :float             (comp convert-float str)
+            :integer           (comp read-string str)
+            :boolean           convert-boolean
+            :offset-date-time  (comp read-instant-timestamp #(replace-first % #" " "T") str)
+            :local-date-time   (comp read-instant-timestamp #(replace-first % #" " "T") str)
+            :local-date        (comp read-instant-timestamp #(replace-first % #" " "T") str)
+            :local-time        (comp local-time str)
+            :date-time         identity
+            :ml-basic-string   str
+            :basic-string      str
+            :ml-literal-string str
+            :literal-string    str
+            :key               str
+            :array             convert-array
+            :std-table         (fn [& xs] [:std-table (into [] xs)])
+            :toml              (fn [& xs] xs)}))
+
+;; Segment end predicates
+
+(defn- segment-separator?
+  "Returns if x separates input into new segment."
+  [x]
+  (let [[t _ _] x]
+    (or (= t :std-table) (= t :array-table))))
+
+;; Value update methods
+
+(defn- update-by-keyval
+  "Updates m with new value v bound to key k."
+  [m k v]
+  (into m {k v}))
+
+(defn- sequence-path
+  "Creates path item for sequential item."
+  [xs ks k]
+  [(conj (conj ks k) (dec (count xs))) (last xs)])
+
+(defn- consume-path
+  "Walks data given the path as far as possible with returning
+  the consumed path and data on it."
+  [data path]
+  (reduce
+   (fn [x y]
+     (let [[ck nk] y
+           ks      (first x)
+           values  (second x)]
+       (cond
+         (nil? ck)                     (reduced x)
+         (not (map? values))           (reduced x)
+         (not (contains? values ck))   (reduced x)
+         (sequential? (get values ck)) (sequence-path (get values ck) ks ck)
+         :else                         [(conj ks ck) (get values ck)])))
+   [[] data]
+   (partition 2 1 (conj (vec path) nil))))
+
+(defn- path-trim-left
+  "Splits xs by ys with returning prefix of path defined by
+  ys found in xs. Data d accompany result."
+  [xs ys d]
+  (loop [xs1   xs
+         ys1   ys
+         taken []]
+    (cond
+      (empty? xs1)                   [taken ys1 d]
+      (number? (first xs1))          (recur (rest xs1) ys1 (conj taken (first xs1)))
+      (empty? ys1)                   [taken ys1 d]
+      (not= (first xs1) (first ys1)) [taken ys1 d]
+      :else                          (recur (rest xs1) (rest ys1) (conj taken (first xs1))))))
+
+(defn- map-swap!
+  "Returns y, intended for usage in update-in for maps."
+  [x y]
+  y)
+
+(defn- analyze-table
+  "Creates combination of present path, rest path and data."
+  [m ks]
+  (let [[path data] (consume-path m ks)]
+    (path-trim-left path ks data)))
+
+;; Standard table update
+
+(defn- standard-table-update
+  "Updates supposedly table value in data on path with
+  mv value."
+  [data path mv]
+  (conj
+   (if (map? data) data {})
+   (if (empty? path)
+     mv
+     (update-in {} path map-swap! mv))))
+
+(defn- array-table-update
+  "Updates path in data with array of tables value represented
+  by mv."
+  [data path mv e?]
+  (let [real-data (if (and e? (empty? path))
+                    {}
+                    (cond
+                      (map? data) data
+                      (sequential? data) data
+                      :else []))]
+    (conj
+     real-data
+     (if (empty? path)
+       mv
+       (update-in {} path map-swap! [mv])))))
+
+(defn- input-table-update
+  "Updates associative structure m with mv on path."
+  [m path mv]
+  (if (empty? path)
+    (into m mv)
+    (update-in m path map-swap! mv)))
+
+;; Standard table update
+
+(defn- update-standard-table
+  "Updates associative structure m with map value mv on path ks."
+  [m ks mv]
+  (let [[present path _] (analyze-table m ks)
+        data             (get-in m present)]
+    (input-table-update m present (standard-table-update data path mv))))
+
+;; Array of tables update
+
+(defn- update-array-table
+  "Updates associative structure m with array of tables mv on path ks."
+  [m ks mv]
+  (let [[present path data] (analyze-table m ks)
+        existing?           (number? (last present))
+        real-present        (if (and existing? (empty? path))
+                              (conj (vec (butlast present)) (inc (last present)))
+                              present)]
+    (input-table-update m real-present (array-table-update data path mv existing?))))
+
+;; Inline array update
+
+(defn- prepare-inline-array
+  "Converts output of Instaparse for inline-table into internal table-like input."
+  [coll]
+  (clojure.walk/prewalk
+   (fn [x]
+     (if (and (sequential? x) (= (first x) :inline-table))
+       (map
+        (fn [x]
+          (if-not (and (sequential? (second x)) (= :inline-table (first (second x))))
+            (assoc {:type :node} :value x)
+            (assoc {:type :table} :key (first x) :value (second x))))
+        (partition 2 (rest x)))
+       x))
+   coll))
+
+(defn- concat-inline-input
+  "Concats inline table-like input with inserting ends of tables."
+  [coll x]
+  (concat (when (and (not= :table-end (:type x)) (not= :node (:type x)))
+            (concat (:value x) [{:type :table-end}]))
+          (rest coll)))
+
+(defn- concat-inline-output
+  "Concats inline table-like output and removes ends of tables."
+  [coll x ctx]
+  (concat coll (condp = (:type x)
+                 :table-end nil
+                 :table     [(assoc x :key (conj ctx (:key x)))]
+                 [x])))
+
+(defn- update-inline-context
+  "Manages context for internal table-like input."
+  [coll x]
+  (condp = (:type x)
+    :table     (conj coll (:key x))
+    :table-end (pop coll)
+    coll))
+
+(defn- flatten-inline-array
+  "Flattens nested structure of inline-table into sequence."
+  [coll]
+  (loop [input  coll
+         output []
+         ctx    []]
+    (if (empty? input)
+      output
+      (let [x (first input)]
+        (recur
+         (concat-inline-input input x)
+         (concat-inline-output output x ctx)
+         (update-inline-context ctx x))))))
+
+(defn- convert-inline-array
+  "Converts inline-table Instaparse output into Instaparse standard table output."
+  [coll]
+  (->> coll
+       prepare-inline-array
+       flatten-inline-array
+       (map (fn [x]
+              (condp = (:type x)
+                :node  (into [:keyval] (:value x))
+                :table (into [:std-table] [(:key x)]))))))
+
+;; Input processing
+
+(declare segment-merge)
+
+(defmulti ^:private process
+  "Processes current segment in input and merges it into values based on type."
+  (fn [type values input] type))
+
+(defmethod ^:private process :keyval
+  [_ values input]
+  (let [[_ k v] (first input)]
+    [(update-by-keyval values k v) (rest input)]))
+
+(defmethod ^:private process :array
+  [_ values input]
+  (let [[_ k v] (first input)]
+    [(update-by-keyval values k v) (rest input)]))
+
+(defmethod ^:private process :inline-table
+  [_ values input]
+  [values (concat (convert-inline-array (first input)) (rest input))])
+
+(defmethod ^:private process :std-table
+  [_ values input]
+  (let [[_ & ks] (first input)
+        [this other] (split-with (complement segment-separator?) (rest input))]
+    [(update-standard-table values (first ks) (segment-merge {} this))
+     other]))
+
+(defmethod ^:private process :array-table
+  [_ values input]
+  (let [[_ & ks] (first input)
+        [this other] (split-with (complement segment-separator?) (rest input))]
+    [(update-array-table values ks (segment-merge {} this))
+     other]))
+
+(defmethod ^:private process :default
+  [_ values input]
+  nil)
+
+;; Merging by segments
+
+(defn- segment-merge
+  "Merges segment into values."
+  [values input]
+  (if (empty? input)
+    values
+    (let [[vs in] (process (ffirst input) values input)]
+      (recur vs in))))
 
 (defn parse-string
-  "Returns the Clojure object corresponding to the given TOML string."
+  "Parses TOML structure from string into Clojure associative structure."
   [^String string]
-  (->> (str string "\n") 
-    toml-parser
-    toml-transform
-    (reduce merge-entries {})))
-
+  (->>
+   string
+   toml-parser
+   toml-transform
+   (segment-merge {})))
 
 (comment
 
   (parse-string "[[foo.bar.\"#baz\"]]
-                a = {foo = \"bar\", baz = 123}") 
+                a = {foo = \"bar\", baz = 123}")
 
   (parse-string "[[fruit]]
                 name = \"apple\"
@@ -143,7 +542,7 @@
                 name = \"granny smith\"
 
                 [[fruit]]
-                name = \"banana\"") 
+                name = \"banana\"")
 
   (parse-string "# ciccio
                 a = 456 
@@ -153,7 +552,7 @@
                 [ foo . bar.\"#baz\"] # lkmasld
                 a = 456
                 b = 123")
-  
+
   (parse-string "b = 123
                 a = [1, 2 , #asd
                 3 , 
@@ -164,5 +563,3 @@
 
                 [foo.bar.\"#baz\"]
                 a = {foo = \"bar\", baz = 123}"))
-
- 

--- a/src/clj_toml/core.clj
+++ b/src/clj_toml/core.clj
@@ -141,9 +141,9 @@
   dec-int = [ minus / plus ] unsigned-dec-int
   <unsigned-dec-int> = DIGIT / digit1-9 1*( DIGIT / <underscore> DIGIT )
 
-  hex-int = hex-prefix HEXDIG *( HEXDIG / underscore HEXDIG )
-  oct-int = oct-prefix digit0-7 *( digit0-7 / underscore digit0-7 )
-  bin-int = bin-prefix digit0-1 *( digit0-1 / underscore digit0-1 )
+  hex-int = hex-prefix HEXDIG *( HEXDIG / <underscore> HEXDIG )
+  oct-int = oct-prefix digit0-7 *( digit0-7 / <underscore> digit0-7 )
+  bin-int = bin-prefix digit0-1 *( digit0-1 / <underscore> digit0-1 )
 
   ;; Float
 

--- a/src/clj_toml/core.clj
+++ b/src/clj_toml/core.clj
@@ -75,21 +75,20 @@
 
   <basic-char> = basic-unescaped / escaped
   <basic-unescaped> = %x20-21 / %x23-5B / %x5D-7E / %x80-10FFFF
-  <escape> = %x5C                    ; \\
 
   <escaped> = escape escape-seq-char
 
-  escape = %x5C                          ; \\
-  escape-seq-char =  escape %x22         ; \"    quotation mark  U+0022
-  escape-seq-char =/ escape %x5C         ; \\    reverse solidus U+005C
-  escape-seq-char =/ escape %x2F         ; /     solidus         U+002F
-  escape-seq-char =/ escape %x62         ; b     backspace       U+0008
-  escape-seq-char =/ escape %x66         ; f     form feed       U+000C
-  escape-seq-char =/ escape %x6E         ; n     line feed       U+000A
-  escape-seq-char =/ escape %x72         ; r     carriage return U+000D
-  escape-seq-char =/ escape %x74         ; t     tab             U+0009
-  escape-seq-char =/ escape %x75 4HEXDIG ; uXXXX                U+XXXX
-  escape-seq-char =/ escape %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
+  <escape> = %x5C                    ; \\
+  <escape-seq-char> =   %x22         ; \"    quotation mark  U+0022
+  <escape-seq-char> =/  %x5C         ; \\    reverse solidus U+005C
+  <escape-seq-char> =/  %x2F         ; /     solidus         U+002F
+  <escape-seq-char> =/  %x62         ; b     backspace       U+0008
+  <escape-seq-char> =/  %x66         ; f     form feed       U+000C
+  <escape-seq-char> =/  %x6E         ; n     line feed       U+000A
+  <escape-seq-char> =/  %x72         ; r     carriage return U+000D
+  <escape-seq-char> =/  %x74         ; t     tab             U+0009
+  <escape-seq-char> =/  %x75 4HEXDIG ; uXXXX                U+XXXX
+  <escape-seq-char> =/  %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
 
   ;; Multiline literals
 

--- a/src/clj_toml/core.clj
+++ b/src/clj_toml/core.clj
@@ -103,7 +103,7 @@
 
   <ml-basic-body> = *( ml-basic-char / ml-newline / ( escape ws ml-newline ) )
   <ml-basic-char> = ml-basic-unescaped / escaped
-  <ml-basic-unescaped> = %x20-5B / %x5D-10FFFF
+  <ml-basic-unescaped> = %x20-5B / %x5D-7E / %x80-10FFFF
 
   ;; Literal String
 

--- a/test/clj_toml/core_test.clj
+++ b/test/clj_toml/core_test.clj
@@ -45,7 +45,11 @@
     (is (= (parse-string "hex = 0x01")
            {"hex" 1}))
     (is (= (parse-string "hex = 0xFFFFFF")
-           {"hex" 16777215})))
+           {"hex" 16777215}))
+    (is (= (parse-string "hex = 0xDEADBEEF")
+           {"hex" 3735928559}))
+    (is (= (parse-string "hex = 0xdead_beef")
+           {"hex" 3735928559})))
   (testing "Integer octal numbers"
     (is (= (parse-string "octal = 0o755")
            {"octal" 493})))

--- a/test/clj_toml/core_test.clj
+++ b/test/clj_toml/core_test.clj
@@ -23,7 +23,6 @@
                           '' = 2")
            {"" 2}))))
 
-;; TODO: find out a way how to test newlines, tabs and such (evaluated by Clojure)
 (deftest string-test
   (testing "Strings (standard)"
     (is (= (parse-string "str = \"I'm a string. Name Jos\u00E9 Location SF.\"")
@@ -166,55 +165,53 @@
 
 ;; TODO: add tests showing that clj-toml is a superset of TOML
 
-(comment
+(deftest example-test
+  (testing "TOML example"
+    (is (= (parse-string (slurp "resources/example.toml"))
+            {"title" "TOML Example"
+            "owner"
+            {"name" "Tom Preston-Werner"
+              "organization" "GitHub"
+              "bio" "GitHub Cofounder & CEO\\nLikes tater tots and beer."
+              "dob" (read-instant-timestamp "1979-05-27T07:32:00Z")}
+            "database"
+            {"enabled" true,
+              "connection_max" 5000,
+              "server" "192.168.1.1",
+              "ports" [8001 8001 8002]}
+            "servers"
+            {"alpha"
+              {"ip" "10.0.0.1"
+              "dc" "eqdc10"}
+              "beta"
+              {"ip" "10.0.0.2"
+              "dc" "eqdc10"
+              "country" "中国"}}
+            "clients"
+            {"data" [["gamma" "delta"] [1 2]]
+              "hosts" ["alpha" "omega"]}
+            "products"
+            [{"name" "Hammer"
+              "sku" 738594937}
+              {"name" "Nail"
+              "sku" 284758393
+              "color" "gray"}]}))))
 
-  (deftest example-test
-    (testing "TOML example"
-      (is (= (parse-string (slurp "resources/example.toml"))
-             {"title" "TOML Example"
-              "owner"
-              {"name" "Tom Preston-Werner"
-               "organization" "GitHub"
-               "bio" "GitHub Cofounder & CEO\nLikes tater tots and beer."
-               "dob" (read-instant-timestamp "1979-05-27T07:32:00Z")}
-              "database"
-              {"enabled" true,
-               "connection_max" 5000,
-               "server" "192.168.1.1",
-               "ports" [8001 8001 8002]}
-              "servers"
-              {"alpha"
-               {"ip" "10.0.0.1"
-                "dc" "eqdc10"}
-               "beta"
-               {"ip" "10.0.0.2"
-                "dc" "eqdc10"
-                "country" "中国"}}
-              "clients"
-              {"data" [["gamma" "delta"] [1 2]]
-               "hosts" ["alpha" "omega"]}
-              "products"
-              [{"name" "Hammer"
-                "sku" 738594937}
-               {"name" "Nail"
-                "sku" 284758393
-                "color" "gray"}]}))))
-
-  (deftest hard-example-test
-    (testing "TOML hard example"
-      (is (= (parse-string (slurp "resources/hard_example.toml"))
-             {"the"
-              {"hard"
-               {"another_test_string" " Same thing, but with a string #",
-                "test_array2"
-                ["Test #11 ]proved that" "Experiment #9 was a success"],
-                "test_array" ["] " " # "],
-                "bit#"
-                {"what?" "You don't think some user won't do that?",
-                 "multi_line_array" ["]"]},
-                "harder_test_string"
-                " And when \"'s are in the string, along with # \""},
-               "test_string" "You'll hate me after this - #"}})))))
+(deftest hard-example-test
+  (testing "TOML hard example"
+    (is (= (parse-string (slurp "resources/hard_example.toml"))
+            {"the"
+            {"hard"
+              {"another_test_string" " Same thing, but with a string #",
+              "test_array2"
+              ["Test #11 ]proved that" "Experiment #9 was a success"],
+              "test_array" ["] " " # "],
+              "bit#"
+              {"what?" "You don't think some user won't do that?",
+                "multi_line_array" ["]"]},
+              "harder_test_string"
+              " And when \\\"'s are in the string, along with # \\\""},
+              "test_string" "You'll hate me after this - #"}}))))
 
 #_(deftest example-v0.4.0-test
     (testing "TOML 0.4.0 example"

--- a/test/clj_toml/core_test.clj
+++ b/test/clj_toml/core_test.clj
@@ -40,7 +40,18 @@
     (is (= (parse-string "integer = +3_0")
            {"integer" 30}))
     (is (= (parse-string "integer = -3_0")
-           {"integer" -30}))))
+           {"integer" -30})))
+  (testing "Integer hexadecimal numbers"
+    (is (= (parse-string "hex = 0x01")
+           {"hex" 1}))
+    (is (= (parse-string "hex = 0xFFFFFF")
+           {"hex" 16777215})))
+  (testing "Integer octal numbers"
+    (is (= (parse-string "octal = 0o755")
+           {"octal" 493})))
+  (testing "Integer binary numbers"
+    (is (= (parse-string "bin = 0b101010")
+           {"bin" 42}))))
 
 (deftest float-test
   (testing "Float point numbers"


### PR DESCRIPTION
This PR implements several features of TOML and also fixes bugs found in older version. Target TOML version
is the actual master of TOML (0.4.0).

## Main changes:

* Usage of TOML ABNF specification from the toml-lang
* Support of array of tables (closes #2)
* Support of string literals
* Support of multiline strings
* Several bugfixes
* Finer granularity tests

## Main points of implementation:

### ABNF

Usage of ABNF specification from toml-lang eases integration of new features and somewhat limits possible
bugs in custom implementation. Specification is similar to one provided in toml-lang with some tweaks for 
easier handling by Instaparse.

### Segments

Input is treated as segmented text, which is divided (currently) by standard tables and array of tables.
Segments determine the paths where values should be merged into the result structure.

### Tables

Table like structures are handled in similar way. Inline tables are converted to standard tables, which 
forces same way of handling (at the end, its just different way of defining table).

## TODO/open points

* Arrays and homogenity checks (stays as before - no checks are made)
* Keys re-opening and checks (stays as before - reopening of keys is allowed)